### PR TITLE
Fix tests that assume python binaries being present

### DIFF
--- a/tests/functional/test_skip_if_binaries_missing.py
+++ b/tests/functional/test_skip_if_binaries_missing.py
@@ -7,6 +7,15 @@
 
     Test the ``@pytest.mark.skip_if_binaries_missing`` marker
 """
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def python_binary():
+    return os.path.basename(sys.executable)
 
 
 def test_skipped(pytester):
@@ -39,30 +48,34 @@ def test_skipped_multiple_binaries(pytester):
     res.stdout.no_fnmatch_line("*PytestUnknownMarkWarning*")
 
 
-def test_not_skipped(pytester):
+def test_not_skipped(pytester, python_binary):
     pytester.makepyfile(
         """
         import pytest
 
-        @pytest.mark.skip_if_binaries_missing("python")
+        @pytest.mark.skip_if_binaries_missing("{}")
         def test_one():
             assert True
-        """
+        """.format(
+            python_binary
+        )
     )
     res = pytester.runpytest_inprocess("-ra", "-vv")
     res.assert_outcomes(passed=1)
     res.stdout.no_fnmatch_line("*PytestUnknownMarkWarning*")
 
 
-def test_not_skipped_multiple_binaries(pytester):
+def test_not_skipped_multiple_binaries(pytester, python_binary):
     pytester.makepyfile(
         """
         import pytest
 
-        @pytest.mark.skip_if_binaries_missing("python", "pip")
+        @pytest.mark.skip_if_binaries_missing("{}", "pip")
         def test_one():
             assert True
-        """
+        """.format(
+            python_binary
+        )
     )
     res = pytester.runpytest_inprocess("-ra", "-vv")
     res.assert_outcomes(passed=1)


### PR DESCRIPTION
On Debian based system, the Python binary includes the version and is named `python3`. The test cases that expect that a binary named `python` exists will fail.

Use the binary name of the running Python process for the test cases to ensure that this binary is present.