### PR TITLE
Fix test_has_local_network if local network is not present

### DIFF
--- a/tests/functional/test_requires_network.py
+++ b/tests/functional/test_requires_network.py
@@ -23,8 +23,13 @@ def test_has_local_network(pytester):
             assert True
         """
     )
-    res = pytester.runpytest()
-    res.assert_outcomes(passed=1)
+    with mock.patch(
+        "pytestskipmarkers.utils.ports.get_unused_localhost_port",
+        side_effect=[ports.get_unused_localhost_port() for n in range(10)],
+    ):
+        with mock.patch("pytestskipmarkers.utils.markers.socket.socket"):
+            res = pytester.runpytest()
+            res.assert_outcomes(passed=1)
     res.stdout.no_fnmatch_line("*PytestUnknownMarkWarning*")
 
 

--- a/tests/unit/utils/markers/test_skip_if_no_remote_network.py
+++ b/tests/unit/utils/markers/test_skip_if_no_remote_network.py
@@ -14,7 +14,8 @@ from pytestskipmarkers.utils import socket
 
 
 def test_has_remote_network():
-    assert markers.skip_if_no_remote_network() is None
+    with mock.patch("pytestskipmarkers.utils.markers.socket.socket"):
+        assert markers.skip_if_no_remote_network() is None
 
 
 def test_no_remote_network():


### PR DESCRIPTION
During Debian package build on the official Debian builders, the `skip_if_no_local_network` will fail. This will cause `test_has_local_network` to fail.

So mock `socket.socket` to ensure that `test_has_local_network` will work regardless of the environment it is executed it.