### PR TITLE
Make sure that, when running under Py3.5, a proper version of more-itertools is installed

### DIFF
--- a/.pylint-spelling-words
+++ b/.pylint-spelling-words
@@ -29,6 +29,7 @@ intersphinx
 intl
 ips
 iterable
+itertools
 linkcheck
 linux
 localhost


### PR DESCRIPTION
Signed-off-by: Pedro Algarvio <palgarvio@vmware.com>