### PR TITLE
Allow installing on older minior versions of Py3.5.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,8 @@ repos:
     hooks:
       - id: flake8
         exclude: ^(src/pytestskipmarkers/(downgraded/.*|version\.py)|\.pre-commit-hooks/.*\.py)$
+        args:
+          - --min-python-version=3.5.6
         additional_dependencies:
         - flake8-mypy-fork
         - flake8-docstrings

--- a/changelog/10.bugfix.rst
+++ b/changelog/10.bugfix.rst
@@ -1,0 +1,1 @@
+Allow installing on older minior versions of Py3.5. Looking at you Debian.

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 package_dir =
     =src
 packages = find:
-python_requires = >= 3.5.6
+python_requires = >= 3.5
 setup_requires =
   setuptools>=50.3.2
   setuptools_scm[toml]>=3.4
@@ -70,6 +70,7 @@ owner = root
 group = root
 
 [flake8]
+min_python_version = 3.5.6
 max-line-length = 120
 exclude =
   # No need to traverse our git directory
@@ -115,7 +116,9 @@ ignore =
   # D200 One-line docstring should fit on one line with quotes
   D200,
   # W503 line break before binary operator
-  W503
+  W503,
+  # TYP001 guard import by TYPE_CHECKING
+  TYP001
 
 # Additional builtins
 builtins =


### PR DESCRIPTION
Looking at you Debian.

Fixes #10

Signed-off-by: Pedro Algarvio <palgarvio@vmware.com>