### PR TITLE
Allow skipping test cases that need Internet access

### DIFF
--- a/changelog/16.feature.rst
+++ b/changelog/16.feature.rst
@@ -1,0 +1,4 @@
+Support skipping all test cases that access the Internet by setting the
+environment variable `NO_INTERNET`. This is useful to make the test run
+reproducible and robust for future runs (to avoid breaking in case some random
+service on the Internet changes).

--- a/src/pytestskipmarkers/downgraded/utils/markers.py
+++ b/src/pytestskipmarkers/downgraded/utils/markers.py
@@ -137,6 +137,8 @@ def skip_if_no_remote_network() -> Optional[str]:
         str: The reason for the skip.
         None: Should not be skipped.
     """
+    if os.environ.get('NO_INTERNET'):
+        return 'Environment variable NO_INTERNET is set'
     has_remote_network = False
     for addr in (
         '172.217.17.14',

--- a/src/pytestskipmarkers/utils/markers.py
+++ b/src/pytestskipmarkers/utils/markers.py
@@ -137,6 +137,9 @@ def skip_if_no_remote_network() -> Optional[str]:
         str: The reason for the skip.
         None: Should not be skipped.
     """
+    if os.environ.get("NO_INTERNET"):
+        return "Environment variable NO_INTERNET is set"
+
     # We are using the google.com DNS records as numerical IPs to avoid
     # DNS look ups which could greatly slow down this check
     has_remote_network = False

--- a/tests/unit/utils/markers/test_skip_if_no_remote_network.py
+++ b/tests/unit/utils/markers/test_skip_if_no_remote_network.py
@@ -4,6 +4,7 @@
 """
 Test the "skip_if_no_remote_network" marker helper.
 """
+import os
 from unittest import mock
 
 import pytestskipmarkers.utils.markers as markers
@@ -22,3 +23,10 @@ def test_no_remote_network():
         skip_reason = markers.skip_if_no_remote_network()
         assert skip_reason is not None
         assert skip_reason == "No internet network connection was detected"
+
+
+def test_remote_network_with_no_internet_env_variable():
+    with mock.patch.dict(os.environ, {"NO_INTERNET": "1"}):
+        skip_reason = markers.skip_if_no_remote_network()
+        assert skip_reason is not None
+        assert skip_reason == "Environment variable NO_INTERNET is set"


### PR DESCRIPTION
Support skipping all test cases that access the Internet by setting the environment variable `NO_INTERNET`. This is useful to make the test run reproducible and robust for future runs (to avoid breaking in case some random service on the Internet changes).