### PR TITLE
Updated platform support for MacOS using arm64 in function is_aarch64

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -111,7 +111,6 @@ jobs:
       max-parallel: 10
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -186,7 +185,6 @@ jobs:
       max-parallel: 10
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -263,7 +261,6 @@ jobs:
       max-parallel: 10
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,10 @@ repos:
         name: Run mypy against source
         files: ^src/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--strict, --no-site-packages, --python-version 3.8]
+        args:
+          - --strict
+          - --no-site-packages
+          - --python-version 3.8
         additional_dependencies:
           - attrs
           - types-attrs
@@ -137,7 +140,9 @@ repos:
         name: Run mypy against tests
         files: ^tests/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--no-site-packages, --python-version 3.8]
+        args:
+          - --no-site-packages
+          - --python-version 3.8
         additional_dependencies:
           - pytest
           - attrs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 ---
-minimum_pre_commit_version: 1.15.2
+minimum_pre_commit_version: 3.6.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict  # Check for files that contain merge conflict strings.
       - id: trailing-whitespace   # Trims trailing whitespace.
@@ -37,7 +37,7 @@ repos:
   # <---- Local Hooks ------------------------------------------------------------------------------------------------
 
   - repo: https://github.com/saltstack/python-tools-scripts
-    rev: "0.20.0"
+    rev: "0.20.5"
     hooks:
       - id: tools
         alias: actionlint
@@ -118,26 +118,26 @@ repos:
         - flake8-typing-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.0
     hooks:
       - id: mypy
         name: Run mypy against source
         files: ^src/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--strict]
+        args: [--strict, --python-version 3.8]
         additional_dependencies:
           - attrs
           - types-attrs
           - types-setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.0
     hooks:
       - id: mypy
         name: Run mypy against tests
         files: ^tests/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: []
+        args: [--python-version 3.8]
         additional_dependencies:
           - pytest
           - attrs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,26 +118,26 @@ repos:
         - flake8-typing-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         name: Run mypy against source
         files: ^src/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--strict, --python-version 3.8, --no-site-packages]
+        args: [--strict, --no-site-packages, --python-version 3.8]
         additional_dependencies:
           - attrs
           - types-attrs
           - types-setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         name: Run mypy against tests
         files: ^tests/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--python-version 3.8, --no-site-packages]
+        args: [--no-site-packages, --python-version 3.8]
         additional_dependencies:
           - pytest
           - attrs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
         name: Run mypy against source
         files: ^src/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--strict, --python-version 3.8]
+        args: [--strict, --python-version 3.8, --no-site-packages]
         additional_dependencies:
           - attrs
           - types-attrs
@@ -137,7 +137,7 @@ repos:
         name: Run mypy against tests
         files: ^tests/.*\.py$
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
-        args: [--python-version 3.8]
+        args: [--python-version 3.8, --no-site-packages]
         additional_dependencies:
           - pytest
           - attrs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
         - flake8-typing-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.11.1
     hooks:
       - id: mypy
         name: Run mypy against source
@@ -134,7 +134,7 @@ repos:
           - types-setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.11.1
     hooks:
       - id: mypy
         name: Run mypy against tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,6 @@ repos:
         args:
           - --strict
           - --no-site-packages
-          - --python-version 3.8
         additional_dependencies:
           - attrs
           - types-attrs
@@ -142,7 +141,6 @@ repos:
         exclude: ^src/pytestskipmarkers/(downgraded/.*|utils/(socket|time)\.py)$
         args:
           - --no-site-packages
-          - --python-version 3.8
         additional_dependencies:
           - pytest
           - attrs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,8 @@ repos:
     rev: v3.15.1
     hooks:
       - id: pyupgrade
-        name: Rewrite Code to be Py3.7+
-        args: [--py37-plus]
+        name: Rewrite Code to be Py3.8+
+        args: [--py38-plus]
 
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.13.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 minimum_pre_commit_version: 1.15.2
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict  # Check for files that contain merge conflict strings.
       - id: trailing-whitespace   # Trims trailing whitespace.
@@ -36,8 +36,8 @@ repos:
         language: system
   # <---- Local Hooks ------------------------------------------------------------------------------------------------
 
-  - repo: https://github.com/s0undt3ch/python-tools-scripts
-    rev: "0.17.0"
+  - repo: https://github.com/saltstack/python-tools-scripts
+    rev: "0.20.0"
     hooks:
       - id: tools
         alias: actionlint
@@ -51,14 +51,14 @@ repos:
 
   # ----- Formatting ------------------------------------------------------------------------------------------------>
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.15.1
     hooks:
       - id: pyupgrade
         name: Rewrite Code to be Py3.7+
         args: [--py37-plus]
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.10.0
+    rev: v3.13.0
     hooks:
       - id: reorder-python-imports
         args: [
@@ -68,25 +68,25 @@ repos:
         exclude: ^src/pytestskipmarkers/(version.py|downgraded/.*)$
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.2.0
     hooks:
       - id: black
         args: [-l 100]
         exclude: ^src/pytestskipmarkers/(version.py|downgraded/.*)$
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.15.0
+    rev: 1.16.0
     hooks:
       - id: blacken-docs
         args: [--skip-errors]
         files: ^(.*\.rst|docs/.*\.rst|src/pytestskipmarkers/.*\.py)$
         additional_dependencies:
-          - black==23.7.0
+          - black==24.2.0
   # <---- Formatting -------------------------------------------------------------------------------------------------
 
   # ----- Security -------------------------------------------------------------------------------------------------->
   - repo: https://github.com/PyCQA/bandit
-    rev: "1.7.5"
+    rev: "1.7.7"
     hooks:
       - id: bandit
         alias: bandit-salt
@@ -97,7 +97,7 @@ repos:
                 tests/.*
             )$
   - repo: https://github.com/PyCQA/bandit
-    rev: "1.7.5"
+    rev: "1.7.7"
     hooks:
       - id: bandit
         alias: bandit-tests
@@ -108,7 +108,7 @@ repos:
 
   # ----- Code Analysis --------------------------------------------------------------------------------------------->
   - repo: https://github.com/pycqa/flake8
-    rev: '6.1.0'
+    rev: '7.1.1'
     hooks:
       - id: flake8
         exclude: ^(src/pytestskipmarkers/(downgraded/.*|version\.py)|\.pre-commit-hooks/.*\.py)$
@@ -118,7 +118,7 @@ repos:
         - flake8-typing-imports
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         name: Run mypy against source
@@ -131,7 +131,7 @@ repos:
           - types-setuptools
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.8.0
     hooks:
       - id: mypy
         name: Run mypy against tests

--- a/.pre-commit-hooks/check-changelog-entries.py
+++ b/.pre-commit-hooks/check-changelog-entries.py
@@ -23,6 +23,8 @@ CHANGELOG_EXTENSIONS = (
 CHANGELOG_ENTRY_REREX = r"^[\d]+\.({})\.rst$".format("|".join(CHANGELOG_EXTENSIONS))
 CHANGELOG_ENTRY_RE = re.compile(CHANGELOG_ENTRY_REREX)
 
+## Example changelog entry: <PR number>.improvement.rst
+
 
 def check_changelog_entries(files):
     exitcode = 0

--- a/changelog/36.improvement.rst
+++ b/changelog/36.improvement.rst
@@ -1,0 +1,1 @@
+Added support for is_arm64 for MacOS and is_x86_64, and updated pre-commit

--- a/changelog/36.improvement.rst
+++ b/changelog/36.improvement.rst
@@ -1,1 +1,1 @@
-Added support for is_arm64 for MacOS and is_x86_64, and updated pre-commit
+Added support for is_arm64 for MacOS and is_x86_64, and updated pre-commit, drop support for Python 3.7

--- a/changelog/36.improvement.rst
+++ b/changelog/36.improvement.rst
@@ -1,1 +1,1 @@
-Added support for is_arm64 for MacOS and is_x86_64, and updated pre-commit, drop support for Python 3.7
+Updated is_aarch64 to allow for MacOS Arm64 using 'arm64' instead of 'aarch64', updated pre-commit, drop support for Python 3.7

--- a/docs/ref/pytestskipmarkers/plugin.rst
+++ b/docs/ref/pytestskipmarkers/plugin.rst
@@ -92,7 +92,7 @@ Markers
             assert True
 
 
-        @pytest.mark.skip_if_binaries_missing("python3.7", "python3", "python", check_all=False)
+        @pytest.mark.skip_if_binaries_missing("python3.8", "python3", "python", check_all=False)
         def test_func():
             assert True
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def session_run_always(session, *command, **kwargs):
             session._runner.global_config.install_only = old_install_only_value
 
 
-@nox.session(python=("3", "3.5", "3.6", "3.7", "3.8", "3.9"))
+@nox.session(python=("3", "3.8", "3.9", "3.10"))
 def tests(session):
     """
     Run tests.

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -2,8 +2,8 @@
 -r tests.txt
 pylint==2.12.2
 pyenchant
-black; python_version >= '3.7'
-reorder-python-imports; python_version >= '3.7'
+black; python_version >= '3.8'
+reorder-python-imports; python_version >= '3.8'
 flake8 >= 4.0.1
 flake8-mypy-fork
 flake8-docstrings

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -35,7 +34,7 @@ include_package_data = True
 package_dir =
     =src
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.8
 setup_requires =
   setuptools>=50.3.2
   setuptools_scm[toml]>=3.4
@@ -133,7 +132,7 @@ docstring-convention = google
 
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 mypy_path = src
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/src/pytestskipmarkers/utils/platform.py
+++ b/src/pytestskipmarkers/utils/platform.py
@@ -111,9 +111,15 @@ def is_aarch64() -> bool:
     """
     if is_darwin():
         # Allow for MacOS Arm64 platform returning differently from Linux
-        return platform.machine().startswith("arm64")
+        # return platform.machine().startswith("arm64")
+        dgm_plmstrg = platform.machine()
+        print(f"DGM is_aarch64 with Darwin True,  dgm_plmstrg '{dgm_plmstrg}'", flush=True)
+        return dgm_plmstrg.startswith("arm64")
     else:
-        return platform.machine().startswith("aarch64")
+        # return platform.machine().startswith("aarch64")
+        dgm_plmstrg = platform.machine()
+        print(f"DSGM is_aarch64 with Darwin False,  dgm_plmstrg '{dgm_plmstrg}'", flush=True)
+        return dgm_plmstrg.startswith("aarch64")
 
 
 def is_photonos() -> bool:

--- a/src/pytestskipmarkers/utils/platform.py
+++ b/src/pytestskipmarkers/utils/platform.py
@@ -152,6 +152,7 @@ def on_platforms(
     openbsd: bool = False,
     aix: bool = False,
     aarch64: bool = False,
+    arm64: bool = False,
     spawning: bool = False,
     photonos: bool = False,
 ) -> bool:
@@ -168,6 +169,7 @@ def on_platforms(
     :keyword bool openbsd: When :py:const:`True`, check if running on OpenBSD.
     :keyword bool aix: When :py:const:`True`, check if running on AIX.
     :keyword bool aarch64: When :py:const:`True`, check if running on AArch64.
+    :keyword bool arm64: When :py:const:`True`, check if running on Arm64.
     :keyword bool spawning:
         When :py:const:`True`, check if running on a platform which defaults
         multiprocessing to spawn
@@ -200,6 +202,9 @@ def on_platforms(
         return True
 
     if aarch64 and is_aarch64():
+        return True
+
+    if arm64 and is_arm64():
         return True
 
     if spawning and is_spawning_platform():

--- a/src/pytestskipmarkers/utils/platform.py
+++ b/src/pytestskipmarkers/utils/platform.py
@@ -112,6 +112,20 @@ def is_aarch64() -> bool:
     return platform.machine().startswith("aarch64")
 
 
+def is_arm64() -> bool:
+    """
+    Simple function to return if host is Arm64 or not.
+    """
+    return platform.machine().startswith("arm64")
+
+
+def is_x86_64() -> bool:
+    """
+    Simple function to return if host is x86_64 or not.
+    """
+    return platform.machine().startswith("x86_64")
+
+
 def is_photonos() -> bool:
     """
     Simple function to return if host is Photon OS or not.

--- a/src/pytestskipmarkers/utils/platform.py
+++ b/src/pytestskipmarkers/utils/platform.py
@@ -109,21 +109,11 @@ def is_aarch64() -> bool:
     """
     Simple function to return if host is AArch64 or not.
     """
-    return platform.machine().startswith("aarch64")
-
-
-def is_arm64() -> bool:
-    """
-    Simple function to return if host is Arm64 or not.
-    """
-    return platform.machine().startswith("arm64")
-
-
-def is_x86_64() -> bool:
-    """
-    Simple function to return if host is x86_64 or not.
-    """
-    return platform.machine().startswith("x86_64")
+    if is_darwin():
+        # Allow for MacOS Arm64 platform returning differently from Linux
+        return platform.machine().startswith("arm64")
+    else:
+        return platform.machine().startswith("aarch64")
 
 
 def is_photonos() -> bool:
@@ -152,7 +142,6 @@ def on_platforms(
     openbsd: bool = False,
     aix: bool = False,
     aarch64: bool = False,
-    arm64: bool = False,
     spawning: bool = False,
     photonos: bool = False,
 ) -> bool:
@@ -169,7 +158,6 @@ def on_platforms(
     :keyword bool openbsd: When :py:const:`True`, check if running on OpenBSD.
     :keyword bool aix: When :py:const:`True`, check if running on AIX.
     :keyword bool aarch64: When :py:const:`True`, check if running on AArch64.
-    :keyword bool arm64: When :py:const:`True`, check if running on Arm64.
     :keyword bool spawning:
         When :py:const:`True`, check if running on a platform which defaults
         multiprocessing to spawn
@@ -202,9 +190,6 @@ def on_platforms(
         return True
 
     if aarch64 and is_aarch64():
-        return True
-
-    if arm64 and is_arm64():
         return True
 
     if spawning and is_spawning_platform():

--- a/src/pytestskipmarkers/utils/platform.py
+++ b/src/pytestskipmarkers/utils/platform.py
@@ -111,15 +111,9 @@ def is_aarch64() -> bool:
     """
     if is_darwin():
         # Allow for MacOS Arm64 platform returning differently from Linux
-        # return platform.machine().startswith("arm64")
-        dgm_plmstrg = platform.machine()
-        print(f"DGM is_aarch64 with Darwin True,  dgm_plmstrg '{dgm_plmstrg}'", flush=True)
-        return dgm_plmstrg.startswith("arm64")
+        return platform.machine().startswith("arm64")
     else:
-        # return platform.machine().startswith("aarch64")
-        dgm_plmstrg = platform.machine()
-        print(f"DSGM is_aarch64 with Darwin False,  dgm_plmstrg '{dgm_plmstrg}'", flush=True)
-        return dgm_plmstrg.startswith("aarch64")
+        return platform.machine().startswith("aarch64")
 
 
 def is_photonos() -> bool:

--- a/tests/unit/utils/test_platform.py
+++ b/tests/unit/utils/test_platform.py
@@ -144,14 +144,16 @@ def test_is_not_aix():
 
 def test_is_aarch64_arm64():
     return_value = True
+    print(f"DGM test_is_aarch64_arm64, expected return value '{return_value}'", flush=True)
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="arm64"):
-        with mock.patch("sys.platform", return_value="darwin"):
+        with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="darwin")):
             assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 
 def test_is_aarch64_aarch64():
     return_value = True
+    print(f"DGM test_is_aarch64_aarch64, expected return value '{return_value}'", flush=True)
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="aarch64"):
         with mock.patch("sys.platform", return_value="not_darwin"):
@@ -160,6 +162,7 @@ def test_is_aarch64_aarch64():
 
 def test_is_not_aarch64():
     return_value = False
+    print(f"DGM test_is_not_aarch64, expected return value '{return_value}'", flush=True)
     with mock.patch("platform.machine", return_value="not_arm64"):
         with mock.patch("sys.platform", return_value="darwin"):
             assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
@@ -167,6 +170,10 @@ def test_is_not_aarch64():
 
 def test_is_not_aarch64_string_aarch64():
     return_value = False
+    print(
+        f"DGM test_is_not_aarch64_string_aarch64, expected return value '{return_value}'",
+        flush=True,
+    )
     with mock.patch("platform.machine", return_value="not_aarch64"):
         assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 

--- a/tests/unit/utils/test_platform.py
+++ b/tests/unit/utils/test_platform.py
@@ -144,13 +144,21 @@ def test_is_not_aix():
 
 def test_is_aarch64():
     return_value = True
-    with mock.patch("platform.machine", return_value="aarch64"):
+    # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
+    with mock.patch("platform.machine", return_value="arm64"):
         assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 
 def test_is_not_aarch64():
     return_value = False
-    with mock.patch("platform.machine", return_value="not_aarch64"):
+    with mock.patch("platform.machine", return_value="not_arm64"):
+        assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
+
+
+def test_is_not_aarch64_string_aarch64():
+    return_value = False
+    # Allow for MacOS Arm64 platform returning differently from Linux
+    with mock.patch("platform.machine", return_value="aarch64"):
         assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 

--- a/tests/unit/utils/test_platform.py
+++ b/tests/unit/utils/test_platform.py
@@ -144,7 +144,6 @@ def test_is_not_aix():
 
 def test_is_aarch64_arm64():
     return_value = True
-    print(f"DGM test_is_aarch64_arm64, expected return value '{return_value}'", flush=True)
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="arm64"):
         with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="darwin")):
@@ -153,7 +152,6 @@ def test_is_aarch64_arm64():
 
 def test_is_aarch64_aarch64():
     return_value = True
-    print(f"DGM test_is_aarch64_aarch64, expected return value '{return_value}'", flush=True)
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="aarch64"):
         with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="not_darwin")):
@@ -162,7 +160,6 @@ def test_is_aarch64_aarch64():
 
 def test_is_not_aarch64():
     return_value = False
-    print(f"DGM test_is_not_aarch64, expected return value '{return_value}'", flush=True)
     with mock.patch("platform.machine", return_value="not_arm64"):
         with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="darwin")):
             assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
@@ -170,10 +167,6 @@ def test_is_not_aarch64():
 
 def test_is_not_aarch64_string_aarch64():
     return_value = False
-    print(
-        f"DGM test_is_not_aarch64_string_aarch64, expected return value '{return_value}'",
-        flush=True,
-    )
     with mock.patch("platform.machine", return_value="not_aarch64"):
         assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 

--- a/tests/unit/utils/test_platform.py
+++ b/tests/unit/utils/test_platform.py
@@ -156,7 +156,7 @@ def test_is_aarch64_aarch64():
     print(f"DGM test_is_aarch64_aarch64, expected return value '{return_value}'", flush=True)
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="aarch64"):
-        with mock.patch("sys.platform", return_value="not_darwin"):
+        with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="not_darwin")):
             assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 
@@ -164,7 +164,7 @@ def test_is_not_aarch64():
     return_value = False
     print(f"DGM test_is_not_aarch64, expected return value '{return_value}'", flush=True)
     with mock.patch("platform.machine", return_value="not_arm64"):
-        with mock.patch("sys.platform", return_value="darwin"):
+        with mock.patch("sys.platform", new_callable=mock.PropertyMock(return_value="darwin")):
             assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 

--- a/tests/unit/utils/test_platform.py
+++ b/tests/unit/utils/test_platform.py
@@ -142,23 +142,32 @@ def test_is_not_aix():
         assert pytestskipmarkers.utils.platform.is_aix() is return_value
 
 
-def test_is_aarch64():
+def test_is_aarch64_arm64():
     return_value = True
     # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
     with mock.patch("platform.machine", return_value="arm64"):
-        assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
+        with mock.patch("sys.platform", return_value="darwin"):
+            assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
+
+
+def test_is_aarch64_aarch64():
+    return_value = True
+    # Allow for MacOS Arm64 platform returns 'arm64' not 'aarch64', different than Linux
+    with mock.patch("platform.machine", return_value="aarch64"):
+        with mock.patch("sys.platform", return_value="not_darwin"):
+            assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 
 def test_is_not_aarch64():
     return_value = False
     with mock.patch("platform.machine", return_value="not_arm64"):
-        assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
+        with mock.patch("sys.platform", return_value="darwin"):
+            assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 
 def test_is_not_aarch64_string_aarch64():
     return_value = False
-    # Allow for MacOS Arm64 platform returning differently from Linux
-    with mock.patch("platform.machine", return_value="aarch64"):
+    with mock.patch("platform.machine", return_value="not_aarch64"):
         assert pytestskipmarkers.utils.platform.is_aarch64() is return_value
 
 


### PR DESCRIPTION
On a MacOS Arm64 system, Python 3 platform.machine() returns ```arm64``` and not ```aarch64``` as on Linux Arm64 systems.

For example: Ubuntu 20.04.05 arm64 (Pi 4), platform.machine() returns ```aarch64```

Hence need to adjust function ```is_aarch64``` to allow for MacOS Arm64 based system reporting differently.

As part of update, updated pre-commit and dropped support for Python 3.7